### PR TITLE
update python version for jobs that run deploy only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             pipenv run pytest
   qa_deploy:
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python:3.7.2
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -40,7 +40,7 @@ jobs:
             pipenv run ansible-playbook -i inventory/qa/hosts playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
   stage_deploy:
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python:3.7.2
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -63,7 +63,7 @@ jobs:
             pipenv run ansible-playbook -i inventory/stage/hosts playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229'
   prod_deploy:
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python:3.7.2
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:


### PR DESCRIPTION
playbook expects python 3.7, but dags are limited to python 3.6 due to airflow being a requirement for the test suite.