### PR TITLE
Circleci import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             sudo pip install pipenv
             SLUGIFY_USES_TEXT_UNIDECODE=yes pipenv install --dev
             pipenv run pylint combine_index_dag -E
-            PYTHONPATH=.. pipenv run pytest
+            PYTHONPATH=. pipenv run pytest
   qa_deploy:
     docker:
       - image: circleci/python:3.7.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             sudo pip install pipenv
             SLUGIFY_USES_TEXT_UNIDECODE=yes pipenv install --dev
             pipenv run pylint combine_index_dag -E
-            pipenv run pytest
+            PYTHONPATH=.. pipenv run pytest
   qa_deploy:
     docker:
       - image: circleci/python:3.7.2

--- a/combine_index_dag.py
+++ b/combine_index_dag.py
@@ -14,7 +14,7 @@ from tulflow import harvest, tasks
 # Functions / any code with processing logic should be elsewhere, tested, etc.
 # This is where to put functions that haven't been abstracted out yet.
 #
-def slackpostonsuccess(FCDAG, **context):
+def slackpostonsuccess(dag, **context):
     """Task Method to Post Successful FunCake Blogs Sync DAG Completion on Slack."""
 
     task_instance = context.get('task_instance')
@@ -26,8 +26,7 @@ def slackpostonsuccess(FCDAG, **context):
         "url": task_instance.log_url
         }
 
-    return tasks.slackpostonsuccess(FCDAG, msg).execute(context=context)
-
+    return tasks.slackpostonsuccess(dag, msg).execute(context=context)
 
 #
 # INIT SYSTEMWIDE VARIABLES

--- a/tests/combine_index_dag_test.py
+++ b/tests/combine_index_dag_test.py
@@ -3,9 +3,9 @@ import os
 import unittest
 import airflow
 try:
-	from funcake_dags.combine_index_dag import FCDAG
-except ImportError as e:	
-	from combine_index_dag import FCDAG
+    from combine_index_dag import FCDAG
+except ImportError:
+    from funcake_dags.combine_index_dag import FCDAG
 
 class TestCombineIndexDAG(unittest.TestCase):
     """Primary Class for Testing the Combine to FunCake Solr Index DAG."""


### PR DESCRIPTION
turns out circleci doesn't name the directory where our repo is cloned the repo name; it is just called project, so funcake_dags import fails. 