### PR TITLE
Source bashrc first

### DIFF
--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -1,14 +1,16 @@
-#/bin/bash --login
+:wq#/bin/bash --login
+
+# required for picking up rbenv variables; source for VMs, export for docker.
+export HOME=$AIRFLOW_USER_HOME
+source ~/.bashrc
+export PATH="$AIRFLOW_HOME/.rbenv/shims:$AIRFLOW_HOME/.rbenv/bin:$PATH"
+
 
 # have any error in following cause bash script to fail
 set -e
 # export / set all environment variables passed here by task for pick-up by subprocess
 set -aux
 
-# required for picking up rbenv variables; source for VMs, export for docker.
-export HOME=$AIRFLOW_USER_HOME
-source ~/.bashrc
-export PATH="$AIRFLOW_HOME/.rbenv/shims:$AIRFLOW_HOME/.rbenv/bin:$PATH"
 
 # grab the funnel cake indexer (ruby / traject) & instal related gems
 git clone https://github.com/tulibraries/funnel_cake_index.git tmp/funnel_cake_index

--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -1,4 +1,4 @@
-:wq#/bin/bash --login
+#/bin/bash --login
 
 # required for picking up rbenv variables; source for VMs, export for docker.
 export HOME=$AIRFLOW_USER_HOME


### PR DESCRIPTION
When we `source ~/.bashrc`, it in turn runs `source /etc/bashrc` which throws an error `PS1: unbound variable` 

Other ingest scripts source first and then `set -e` to fail on errors, which seems like a sensible appaorch since we don't actually care about `$PS1`

