### PR TITLE
Lookup dag specific *_TARGET_ALIAS_ENV

### DIFF
--- a/funcake_dplah_dag.py
+++ b/funcake_dplah_dag.py
@@ -60,7 +60,7 @@ XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
 # Publication-related Solr URL, Configset, Alias
 SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
 SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
-TARGET_ALIAS_ENV = Variable.get("TARGET_ALIAS_ENV", default_var="dev")
+TARGET_ALIAS_ENV = Variable.get("DPLAH_TARGET_ALIAS_ENV", default_var="dev")
 
 # Data Bucket Variables
 AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")

--- a/funcake_free_library_of_philadelphia_dag.py
+++ b/funcake_free_library_of_philadelphia_dag.py
@@ -49,7 +49,7 @@ AIRFLOW_DATA_BUCKET = Variable.get("AIRFLOW_DATA_BUCKET")
 # Publication-related Solr URL, Configset, Alias
 SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
 SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
-TARGET_ALIAS_ENV = Variable.get("TARGET_ALIAS_ENV", default_var="dev")
+TARGET_ALIAS_ENV = Variable.get("FREE_LIBRARY_TARGET_ALIAS_ENV", default_var="dev")
 
 # Define the DAG
 DEFAULT_ARGS = {

--- a/funcake_historic_pitt_dag.py
+++ b/funcake_historic_pitt_dag.py
@@ -62,7 +62,7 @@ XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
 # Publication-related Solr URL, Configset, Alias
 SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
 SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
-TARGET_ALIAS_ENV = Variable.get("TARGET_ALIAS_ENV", default_var="dev")
+TARGET_ALIAS_ENV = Variable.get("HISTORIC_PITT_TARGET_ALIAS_ENV", default_var="dev")
 
 # Data Bucket Variables
 AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")

--- a/funcake_temple_dag.py
+++ b/funcake_temple_dag.py
@@ -62,7 +62,7 @@ XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
 # Publication-related Solr URL, Configset, Alias
 SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
 SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
-TARGET_ALIAS_ENV = Variable.get("TARGET_ALIAS_ENV", default_var="dev")
+TARGET_ALIAS_ENV = Variable.get("TEMPLE_TARGET_ALIAS_ENV", default_var="dev")
 
 # Data Bucket Variables
 AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")

--- a/funcake_villanova_dag.py
+++ b/funcake_villanova_dag.py
@@ -61,7 +61,7 @@ XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
 # Publication-related Solr URL, Configset, Alias
 SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
 SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
-TARGET_ALIAS_ENV = Variable.get("TARGET_ALIAS_ENV", default_var="dev")
+TARGET_ALIAS_ENV = Variable.get("VILLANOVA_TARGET_ALIAS_ENV", default_var="dev")
 
 # Data Bucket Variables
 AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")


### PR DESCRIPTION
Currently all using the generic TARGET_ALIAS_ENV which is not defined,
and thus all are always defaulting to dev