### PR TITLE
FLYPIE-196 Add funcake template dag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ tty-root-webserver:
 
 tty-root-scheduler:
 	$(INTO-SUBMODULE) && $(MAKE) tty-root-scheduler
+
+load-vars:
+	$(INTO-SUBMODULE) && $(MAKE) load-vars

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ down:
 tty-webserver:
 	$(INTO-SUBMODULE) && $(MAKE) tty-root-webserver
 
-tty-schedular:
-	$(INTO-SUBMODULE) && $(MAKE) tty-schedular
+tty-scheduler:
+	$(INTO-SUBMODULE) && $(MAKE) tty-scheduler
+
+tty-worker:
+	$(INTO-SUBMODULE) && $(MAKE) tty-worker
 
 tty-root-worker:
 	$(INTO-SUBMODULE) && $(MAKE) tty-root-worker
@@ -26,6 +29,5 @@ tty-root-worker:
 tty-root-webserver:
 	$(INTO-SUBMODULE) && $(MAKE) tty-root-webserver
 
-tty-root-schedular:
-	$(INTO-SUBMODULE) && $(MAKE) tty-root-schedular
-
+tty-root-scheduler:
+	$(INTO-SUBMODULE) && $(MAKE) tty-root-scheduler

--- a/funcake_dags/funcake_westchester_dag.py
+++ b/funcake_dags/funcake_westchester_dag.py
@@ -1,15 +1,32 @@
-from funcake_dags.template import create_dag
+"""DAG to Harvest West Chester OAI & Index ("Publish") to SolrCloud."""
+from datetime import datetime, timedelta
 from airflow import DAG
+from airflow.hooks.base_hook import BaseHook
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.bash_operator import BashOperator
+from tulflow import harvest, tasks, transform, validate
+from airflow.models import DagRun
+from funcake_dags.task_slack_posts import slackpostonfail, slackpostonsuccess
 
-DAG = create_dag(
-    dag_id="funcake_westchester",
-    oai_config_name="WESTCHESTER_OAI_CONFIG",
-    xsl_config_name="WESTCHESTER_XSL_CONFIG",
-    target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")
+"""
+LOCAL FUNCTIONS
+Functions / any code with processing logic should be elsewhere, tested, etc.
+This is where to put functions that haven't been abstracted out yet.
+"""
 
-globals()[DAG.dag_id] = DAG
+"""
+INIT SYSTEMWIDE VARIABLES
+check for existence of systemwide variables shared across tasks that can be
+initialized here if not found (i.e. if this is a new installation) & defaults exist
+"""
 
-# Example OAI Harvest Config Variable
+AIRFLOW_APP_HOME = Variable.get("AIRFLOW_HOME")
+AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
+SCRIPTS_PATH = AIRFLOW_APP_HOME + "/dags/funcake_dags/scripts"
+
+# Combine OAI Harvest Variables
+OAI_CONFIG = Variable.get("WESTCHESTER_OAI_CONFIG", deserialize_json=True)
 # {
 #   "endpoint": "http://digital.klnpa.org/oai/oai.php",
 #   "md_prefix": "oai_qdc",
@@ -20,8 +37,16 @@ globals()[DAG.dag_id] = DAG
 #   "schematron_report": "validations/padigital_missing_thumbnailURL.sch"
 # }
 
+OAI_MD_PREFIX = OAI_CONFIG.get("md_prefix")
+OAI_INCLUDED_SETS = OAI_CONFIG.get("included_sets")
+OAI_ENDPOINT = OAI_CONFIG.get("endpoint")
+OAI_EXCLUDED_SETS = OAI_CONFIG.get("excluded_sets", [])
+OAI_ALL_SETS = OAI_CONFIG.get("excluded_sets", "False")
+OAI_SCHEMATRON_FILTER = OAI_CONFIG.get("schematron_filter", "validations/qdcingest_reqd_fields.sch")
+OAI_SCHEMATRON_REPORT = OAI_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
 
-# Example XSL Config Variable
+XSL_CONFIG = Variable.get("WESTCHESTER_XSL_CONFIG", deserialize_json=True)
+#XSL_CONFIG = Variable.get("WESTCHESTER_XSL_CONFIG", default_var={}, deserialize_json=True)
 #{
 #   "schematron_filter": "validations/funcake_reqd_fields.sch",
 #   "schematron_report": "validations/padigital_missing_thumbnailURL.sch",
@@ -29,3 +54,195 @@ globals()[DAG.dag_id] = DAG
 #   "xsl_filename": "transforms/dplah.xsl",
 #   "xsl_repository": "tulibraries/aggregator_mdx" <--- OPTIONAL
 # }
+XSL_SCHEMATRON_FILTER = XSL_CONFIG.get("schematron_filter", "validations/padigital_reqd_fields.sch")
+XSL_SCHEMATRON_REPORT = XSL_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
+XSL_BRANCH = XSL_CONFIG.get("xsl_branch", "master")
+XSL_FILENAME = XSL_CONFIG.get("xsl_filename", "transforms/KLNqdcCDMingest_test.xsl")
+XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
+
+# Publication-related Solr URL, Configset, Alias
+SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
+SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
+TARGET_ALIAS_ENV = Variable.get("WESTCHESTER_TARGET_ALIAS_ENV", default_var="dev")
+
+# Data Bucket Variables
+AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")
+AIRFLOW_DATA_BUCKET = Variable.get("AIRFLOW_DATA_BUCKET")
+
+# Define the DAG
+DEFAULT_ARGS = {
+    "owner": "dpla",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 8, 27),
+    "on_failure_callback": slackpostonfail,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=10),
+}
+
+DAG = DAG(
+    dag_id="funcake_westchester",
+    default_args=DEFAULT_ARGS,
+    catchup=False,
+    max_active_runs=1,
+    schedule_interval=None
+)
+
+"""
+CREATE TASKS
+Tasks with all logic contained in a single operator can be declared here.
+Tasks with custom logic are relegated to individual Python files.
+"""
+
+SET_COLLECTION_NAME = PythonOperator(
+    task_id="set_collection_name",
+    python_callable=datetime.now().strftime,
+    op_args=["%Y-%m-%d_%H-%M-%S"],
+    dag=DAG
+)
+
+OAI_TO_S3 = PythonOperator(
+    task_id="harvest_oai",
+    provide_context=True,
+    python_callable=harvest.oai_to_s3,
+    op_kwargs={
+        "access_id": AIRFLOW_S3.login,
+        "access_secret": AIRFLOW_S3.password,
+        "all_sets": OAI_ALL_SETS,
+        "bucket_name": AIRFLOW_DATA_BUCKET,
+        "excluded_sets": OAI_EXCLUDED_SETS,
+        "included_sets": OAI_INCLUDED_SETS,
+        "metadata_prefix": OAI_MD_PREFIX,
+        "oai_endpoint": OAI_ENDPOINT,
+        "records_per_file": 10000,
+        "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+    },
+    dag=DAG
+)
+
+HARVEST_SCHEMATRON_REPORT = PythonOperator(
+    task_id="harvest_schematron_report",
+    provide_context=True,
+    python_callable=validate.report_s3_schematron,
+    op_kwargs={
+        "access_id": AIRFLOW_S3.login,
+        "access_secret": AIRFLOW_S3.password,
+        "bucket": AIRFLOW_DATA_BUCKET,
+        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated",
+        "schematron_filename": OAI_SCHEMATRON_REPORT,
+        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/"
+    },
+    dag=DAG
+)
+
+HARVEST_FILTER = PythonOperator(
+    task_id="harvest_filter",
+    provide_context=True,
+    python_callable=validate.filter_s3_schematron,
+    op_kwargs={
+        "access_id": AIRFLOW_S3.login,
+        "access_secret": AIRFLOW_S3.password,
+        "bucket": AIRFLOW_DATA_BUCKET,
+        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated-filtered/",
+        "report_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/harvest_filter",
+        "schematron_filename": OAI_SCHEMATRON_FILTER,
+        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/",
+        "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+    },
+    dag=DAG
+)
+
+XSL_TRANSFORM = BashOperator(
+    task_id="xsl_transform",
+    bash_command=SCRIPTS_PATH + "/transform.sh ",
+    env={
+        "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
+        "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
+        "BUCKET": AIRFLOW_DATA_BUCKET,
+        "DAG_ID": DAG.dag_id,
+        "DAG_TS": "{{ ti.xcom_pull(task_ids='set_collection_name') }}",
+        "DEST": "transformed",
+        "SOURCE": "new-updated-filtered",
+        "SCRIPTS_PATH": SCRIPTS_PATH,
+        "XSL_BRANCH": XSL_BRANCH,
+        "XSL_FILENAME": XSL_FILENAME,
+        "XSL_REPO": XSL_REPO,
+    },
+    dag=DAG
+)
+
+XSL_TRANSFORM_SCHEMATRON_REPORT = PythonOperator(
+    task_id="xsl_transform_schematron_report",
+    provide_context=True,
+    python_callable=validate.report_s3_schematron,
+    op_kwargs={
+        "access_id": AIRFLOW_S3.login,
+        "access_secret": AIRFLOW_S3.password,
+        "bucket": AIRFLOW_DATA_BUCKET,
+        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed",
+        "schematron_filename": XSL_SCHEMATRON_REPORT,
+        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/"
+    },
+    dag=DAG
+)
+
+XSL_TRANSFORM_FILTER = PythonOperator(
+    task_id="xsl_transform_filter",
+    provide_context=True,
+    python_callable=validate.filter_s3_schematron,
+    op_kwargs={
+        "access_id": AIRFLOW_S3.login,
+        "access_secret": AIRFLOW_S3.password,
+        "bucket": AIRFLOW_DATA_BUCKET,
+        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
+        "schematron_filename": XSL_SCHEMATRON_FILTER,
+        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/",
+        "report_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed_filtered",
+        "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+    },
+    dag=DAG
+)
+
+REFRESH_COLLECTION_FOR_ALIAS = tasks.refresh_sc_collection_for_alias(
+    DAG,
+    sc_conn=SOLR_CONN,
+    sc_coll_name=f"{SOLR_CONFIGSET}-{DAG.dag_id}-{TARGET_ALIAS_ENV}",
+    sc_alias=f"{SOLR_CONFIGSET}-{TARGET_ALIAS_ENV}",
+    configset=SOLR_CONFIGSET
+)
+
+PUBLISH = BashOperator(
+    task_id="publish",
+    bash_command=SCRIPTS_PATH + "/index.sh ",
+    env={
+        "BUCKET": AIRFLOW_DATA_BUCKET,
+        "FOLDER": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
+        "INDEXER": "oai_index",
+        "FUNCAKE_OAI_SOLR_URL": tasks.get_solr_url(SOLR_CONN, SOLR_CONFIGSET + "-" + DAG.dag_id + "-" + TARGET_ALIAS_ENV),
+        "SOLR_AUTH_USER": SOLR_CONN.login or "",
+        "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
+        "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
+        "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
+        "AIRFLOW_USER_HOME": AIRFLOW_USER_HOME
+    },
+    dag=DAG
+)
+
+NOTIFY_SLACK = PythonOperator(
+    task_id="success_slack_trigger",
+    provide_context=True,
+    python_callable=slackpostonsuccess,
+    dag=DAG
+)
+
+# SET UP TASK DEPENDENCIES
+OAI_TO_S3.set_upstream(SET_COLLECTION_NAME)
+HARVEST_SCHEMATRON_REPORT.set_upstream(OAI_TO_S3)
+HARVEST_FILTER.set_upstream(OAI_TO_S3)
+XSL_TRANSFORM.set_upstream(HARVEST_SCHEMATRON_REPORT)
+XSL_TRANSFORM.set_upstream(HARVEST_FILTER)
+XSL_TRANSFORM_SCHEMATRON_REPORT.set_upstream(XSL_TRANSFORM)
+XSL_TRANSFORM_FILTER.set_upstream(XSL_TRANSFORM)
+REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_SCHEMATRON_REPORT)
+REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_FILTER)
+PUBLISH.set_upstream(REFRESH_COLLECTION_FOR_ALIAS)
+NOTIFY_SLACK.set_upstream(PUBLISH)

--- a/funcake_dags/funcake_westchester_dag.py
+++ b/funcake_dags/funcake_westchester_dag.py
@@ -1,11 +1,12 @@
 from funcake_dags.template import create_dag
 
+DAG_ID = "funcake_westchester"
+globals()[DAG_ID] = create_dag(
+    dag_id=DAG_ID,
+    oai_config_name="WESTCHESTER_OAI_CONFIG",
+    xsl_config_name="WESTCHESTER_XSL_CONFIG",
+    target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")
 
-DAG = create_dag(
-        dag_id="westchester",
-        oai_config_name="WESTCHESTER_OAI_CONFIG",
-        xsl_config_name="WESTCHESTER_XSL_CONFIG",
-        target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")
 
 # Example OAI Harvest Config Variable
 # {

--- a/funcake_dags/funcake_westchester_dag.py
+++ b/funcake_dags/funcake_westchester_dag.py
@@ -2,7 +2,7 @@ from funcake_dags.template import create_dag
 
 
 DAG = create_dag(
-        dag_id="foo",
+        dag_id="westchester",
         oai_config_name="WESTCHESTER_OAI_CONFIG",
         xsl_config_name="WESTCHESTER_XSL_CONFIG",
         target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")

--- a/funcake_dags/funcake_westchester_dag.py
+++ b/funcake_dags/funcake_westchester_dag.py
@@ -1,11 +1,13 @@
 from funcake_dags.template import create_dag
+from airflow import DAG
 
-create_dag(
+DAG = create_dag(
     dag_id="funcake_westchester",
     oai_config_name="WESTCHESTER_OAI_CONFIG",
     xsl_config_name="WESTCHESTER_XSL_CONFIG",
     target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")
 
+globals()[DAG.dag_id] = DAG
 
 # Example OAI Harvest Config Variable
 # {

--- a/funcake_dags/funcake_westchester_dag.py
+++ b/funcake_dags/funcake_westchester_dag.py
@@ -1,32 +1,13 @@
-"""DAG to Harvest West Chester OAI & Index ("Publish") to SolrCloud."""
-from datetime import datetime, timedelta
-from airflow import DAG
-from airflow.hooks.base_hook import BaseHook
-from airflow.models import Variable
-from airflow.operators.python_operator import PythonOperator
-from airflow.operators.bash_operator import BashOperator
-from tulflow import harvest, tasks, transform, validate
-from airflow.models import DagRun
-from funcake_dags.task_slack_posts import slackpostonfail, slackpostonsuccess
+from funcake_dags.template import create_dag
 
-"""
-LOCAL FUNCTIONS
-Functions / any code with processing logic should be elsewhere, tested, etc.
-This is where to put functions that haven't been abstracted out yet.
-"""
 
-"""
-INIT SYSTEMWIDE VARIABLES
-check for existence of systemwide variables shared across tasks that can be
-initialized here if not found (i.e. if this is a new installation) & defaults exist
-"""
+DAG = create_dag(
+        dag_id="foo",
+        oai_config_name="WESTCHESTER_OAI_CONFIG",
+        xsl_config_name="WESTCHESTER_XSL_CONFIG",
+        target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")
 
-AIRFLOW_APP_HOME = Variable.get("AIRFLOW_HOME")
-AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
-SCRIPTS_PATH = AIRFLOW_APP_HOME + "/dags/funcake_dags/scripts"
-
-# Combine OAI Harvest Variables
-OAI_CONFIG = Variable.get("WESTCHESTER_OAI_CONFIG", deserialize_json=True)
+# Example OAI Harvest Config Variable
 # {
 #   "endpoint": "http://digital.klnpa.org/oai/oai.php",
 #   "md_prefix": "oai_qdc",
@@ -37,16 +18,8 @@ OAI_CONFIG = Variable.get("WESTCHESTER_OAI_CONFIG", deserialize_json=True)
 #   "schematron_report": "validations/padigital_missing_thumbnailURL.sch"
 # }
 
-OAI_MD_PREFIX = OAI_CONFIG.get("md_prefix")
-OAI_INCLUDED_SETS = OAI_CONFIG.get("included_sets")
-OAI_ENDPOINT = OAI_CONFIG.get("endpoint")
-OAI_EXCLUDED_SETS = OAI_CONFIG.get("excluded_sets", [])
-OAI_ALL_SETS = OAI_CONFIG.get("excluded_sets", "False")
-OAI_SCHEMATRON_FILTER = OAI_CONFIG.get("schematron_filter", "validations/qdcingest_reqd_fields.sch")
-OAI_SCHEMATRON_REPORT = OAI_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
 
-XSL_CONFIG = Variable.get("WESTCHESTER_XSL_CONFIG", deserialize_json=True)
-#XSL_CONFIG = Variable.get("WESTCHESTER_XSL_CONFIG", default_var={}, deserialize_json=True)
+# Example XSL Config Variable
 #{
 #   "schematron_filter": "validations/funcake_reqd_fields.sch",
 #   "schematron_report": "validations/padigital_missing_thumbnailURL.sch",
@@ -54,195 +27,3 @@ XSL_CONFIG = Variable.get("WESTCHESTER_XSL_CONFIG", deserialize_json=True)
 #   "xsl_filename": "transforms/dplah.xsl",
 #   "xsl_repository": "tulibraries/aggregator_mdx" <--- OPTIONAL
 # }
-XSL_SCHEMATRON_FILTER = XSL_CONFIG.get("schematron_filter", "validations/padigital_reqd_fields.sch")
-XSL_SCHEMATRON_REPORT = XSL_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
-XSL_BRANCH = XSL_CONFIG.get("xsl_branch", "master")
-XSL_FILENAME = XSL_CONFIG.get("xsl_filename", "transforms/KLNqdcCDMingest_test.xsl")
-XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
-
-# Publication-related Solr URL, Configset, Alias
-SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
-SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
-TARGET_ALIAS_ENV = Variable.get("WESTCHESTER_TARGET_ALIAS_ENV", default_var="dev")
-
-# Data Bucket Variables
-AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")
-AIRFLOW_DATA_BUCKET = Variable.get("AIRFLOW_DATA_BUCKET")
-
-# Define the DAG
-DEFAULT_ARGS = {
-    "owner": "dpla",
-    "depends_on_past": False,
-    "start_date": datetime(2019, 8, 27),
-    "on_failure_callback": slackpostonfail,
-    "retries": 0,
-    "retry_delay": timedelta(minutes=10),
-}
-
-DAG = DAG(
-    dag_id="funcake_westchester",
-    default_args=DEFAULT_ARGS,
-    catchup=False,
-    max_active_runs=1,
-    schedule_interval=None
-)
-
-"""
-CREATE TASKS
-Tasks with all logic contained in a single operator can be declared here.
-Tasks with custom logic are relegated to individual Python files.
-"""
-
-SET_COLLECTION_NAME = PythonOperator(
-    task_id="set_collection_name",
-    python_callable=datetime.now().strftime,
-    op_args=["%Y-%m-%d_%H-%M-%S"],
-    dag=DAG
-)
-
-OAI_TO_S3 = PythonOperator(
-    task_id="harvest_oai",
-    provide_context=True,
-    python_callable=harvest.oai_to_s3,
-    op_kwargs={
-        "access_id": AIRFLOW_S3.login,
-        "access_secret": AIRFLOW_S3.password,
-        "all_sets": OAI_ALL_SETS,
-        "bucket_name": AIRFLOW_DATA_BUCKET,
-        "excluded_sets": OAI_EXCLUDED_SETS,
-        "included_sets": OAI_INCLUDED_SETS,
-        "metadata_prefix": OAI_MD_PREFIX,
-        "oai_endpoint": OAI_ENDPOINT,
-        "records_per_file": 10000,
-        "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
-    },
-    dag=DAG
-)
-
-HARVEST_SCHEMATRON_REPORT = PythonOperator(
-    task_id="harvest_schematron_report",
-    provide_context=True,
-    python_callable=validate.report_s3_schematron,
-    op_kwargs={
-        "access_id": AIRFLOW_S3.login,
-        "access_secret": AIRFLOW_S3.password,
-        "bucket": AIRFLOW_DATA_BUCKET,
-        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated",
-        "schematron_filename": OAI_SCHEMATRON_REPORT,
-        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/"
-    },
-    dag=DAG
-)
-
-HARVEST_FILTER = PythonOperator(
-    task_id="harvest_filter",
-    provide_context=True,
-    python_callable=validate.filter_s3_schematron,
-    op_kwargs={
-        "access_id": AIRFLOW_S3.login,
-        "access_secret": AIRFLOW_S3.password,
-        "bucket": AIRFLOW_DATA_BUCKET,
-        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated-filtered/",
-        "report_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/harvest_filter",
-        "schematron_filename": OAI_SCHEMATRON_FILTER,
-        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/",
-        "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
-    },
-    dag=DAG
-)
-
-XSL_TRANSFORM = BashOperator(
-    task_id="xsl_transform",
-    bash_command=SCRIPTS_PATH + "/transform.sh ",
-    env={
-        "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
-        "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
-        "BUCKET": AIRFLOW_DATA_BUCKET,
-        "DAG_ID": DAG.dag_id,
-        "DAG_TS": "{{ ti.xcom_pull(task_ids='set_collection_name') }}",
-        "DEST": "transformed",
-        "SOURCE": "new-updated-filtered",
-        "SCRIPTS_PATH": SCRIPTS_PATH,
-        "XSL_BRANCH": XSL_BRANCH,
-        "XSL_FILENAME": XSL_FILENAME,
-        "XSL_REPO": XSL_REPO,
-    },
-    dag=DAG
-)
-
-XSL_TRANSFORM_SCHEMATRON_REPORT = PythonOperator(
-    task_id="xsl_transform_schematron_report",
-    provide_context=True,
-    python_callable=validate.report_s3_schematron,
-    op_kwargs={
-        "access_id": AIRFLOW_S3.login,
-        "access_secret": AIRFLOW_S3.password,
-        "bucket": AIRFLOW_DATA_BUCKET,
-        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed",
-        "schematron_filename": XSL_SCHEMATRON_REPORT,
-        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/"
-    },
-    dag=DAG
-)
-
-XSL_TRANSFORM_FILTER = PythonOperator(
-    task_id="xsl_transform_filter",
-    provide_context=True,
-    python_callable=validate.filter_s3_schematron,
-    op_kwargs={
-        "access_id": AIRFLOW_S3.login,
-        "access_secret": AIRFLOW_S3.password,
-        "bucket": AIRFLOW_DATA_BUCKET,
-        "destination_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
-        "schematron_filename": XSL_SCHEMATRON_FILTER,
-        "source_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/",
-        "report_prefix": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed_filtered",
-        "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
-    },
-    dag=DAG
-)
-
-REFRESH_COLLECTION_FOR_ALIAS = tasks.refresh_sc_collection_for_alias(
-    DAG,
-    sc_conn=SOLR_CONN,
-    sc_coll_name=f"{SOLR_CONFIGSET}-{DAG.dag_id}-{TARGET_ALIAS_ENV}",
-    sc_alias=f"{SOLR_CONFIGSET}-{TARGET_ALIAS_ENV}",
-    configset=SOLR_CONFIGSET
-)
-
-PUBLISH = BashOperator(
-    task_id="publish",
-    bash_command=SCRIPTS_PATH + "/index.sh ",
-    env={
-        "BUCKET": AIRFLOW_DATA_BUCKET,
-        "FOLDER": DAG.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
-        "INDEXER": "oai_index",
-        "FUNCAKE_OAI_SOLR_URL": tasks.get_solr_url(SOLR_CONN, SOLR_CONFIGSET + "-" + DAG.dag_id + "-" + TARGET_ALIAS_ENV),
-        "SOLR_AUTH_USER": SOLR_CONN.login or "",
-        "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
-        "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
-        "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
-        "AIRFLOW_USER_HOME": AIRFLOW_USER_HOME
-    },
-    dag=DAG
-)
-
-NOTIFY_SLACK = PythonOperator(
-    task_id="success_slack_trigger",
-    provide_context=True,
-    python_callable=slackpostonsuccess,
-    dag=DAG
-)
-
-# SET UP TASK DEPENDENCIES
-OAI_TO_S3.set_upstream(SET_COLLECTION_NAME)
-HARVEST_SCHEMATRON_REPORT.set_upstream(OAI_TO_S3)
-HARVEST_FILTER.set_upstream(OAI_TO_S3)
-XSL_TRANSFORM.set_upstream(HARVEST_SCHEMATRON_REPORT)
-XSL_TRANSFORM.set_upstream(HARVEST_FILTER)
-XSL_TRANSFORM_SCHEMATRON_REPORT.set_upstream(XSL_TRANSFORM)
-XSL_TRANSFORM_FILTER.set_upstream(XSL_TRANSFORM)
-REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_SCHEMATRON_REPORT)
-REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_FILTER)
-PUBLISH.set_upstream(REFRESH_COLLECTION_FOR_ALIAS)
-NOTIFY_SLACK.set_upstream(PUBLISH)

--- a/funcake_dags/funcake_westchester_dag.py
+++ b/funcake_dags/funcake_westchester_dag.py
@@ -1,8 +1,7 @@
 from funcake_dags.template import create_dag
 
-DAG_ID = "funcake_westchester"
-globals()[DAG_ID] = create_dag(
-    dag_id=DAG_ID,
+create_dag(
+    dag_id="funcake_westchester",
     oai_config_name="WESTCHESTER_OAI_CONFIG",
     xsl_config_name="WESTCHESTER_XSL_CONFIG",
     target_alias_env_name="WESTCHESTER_TARGET_ALIAS_ENV")

--- a/funcake_dags/template.py
+++ b/funcake_dags/template.py
@@ -7,6 +7,7 @@ from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 from funcake_dags.task_slack_posts import slackpostonfail, slackpostonsuccess
 from tulflow import harvest, tasks, transform, validate
+import os
 
 # Define the DAG
 DEFAULT_ARGS = {
@@ -32,7 +33,63 @@ SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
 
 SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
 
-def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
+
+def namespace(dag_id):
+    if dag_id[0:8] != "funcake_":
+        dag_id = "funcake_" + dag_id
+    return dag_id
+
+
+def unnamespace(dag_id):
+    if dag_id[0:8] == "funcake_":
+        dag_id = dag_id[8:]
+    return dag_id
+
+
+def name(dag_id):
+    return unnamespace(dag_id).upper()
+
+
+def get_harvest_task(dag, config):
+    if config.get("endpoint") == None:
+        return BashOperator(
+                task_id="harvest_csv",
+                bash_command="csv_transform_to_s3.sh ",
+                env={**os.environ, **{
+                    "PATH": os.environ.get("PATH", "") + ":" + SCRIPTS_PATH,
+                    "DAGID": dag.dag_id,
+                    "HOME": AIRFLOW_USER_HOME,
+                    "AIRFLOW_APP_HOME": AIRFLOW_APP_HOME,
+                    "BUCKET": AIRFLOW_DATA_BUCKET,
+                    "FOLDER": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated",
+                    "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
+                    "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
+                    "TIMESTAMP": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+                    }},
+                dag=dag)
+
+    else:
+        return PythonOperator(
+                task_id="harvest_oai",
+                provide_context=True,
+                python_callable=harvest.oai_to_s3,
+                op_kwargs={
+                    "access_id": AIRFLOW_S3.login,
+                    "access_secret": AIRFLOW_S3.password,
+                    "all_sets": config.get("all_sets", "False"),
+                    "bucket_name": AIRFLOW_DATA_BUCKET,
+                    "excluded_sets": config.get("execluded_sets", []),
+                    "included_sets": config.get("included_sets"),
+                    "metadata_prefix": config.get("md_prefix"),
+                    "oai_endpoint": config.get("endpoint"),
+                    "records_per_file": 10000,
+                    "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+                    },
+                dag=dag)
+
+
+def create_dag(dag_id):
+    dag_id = namespace(dag_id)
     dag = DAG(
             dag_id=dag_id,
             default_args=DEFAULT_ARGS,
@@ -40,21 +97,20 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
             max_active_runs=1,
             schedule_interval=None)
 
-    OAI_CONFIG = Variable.get(oai_config_name, deserialize_json=True)
-    OAI_MD_PREFIX = OAI_CONFIG.get("md_prefix")
-    OAI_INCLUDED_SETS = OAI_CONFIG.get("included_sets")
-    OAI_ENDPOINT = OAI_CONFIG.get("endpoint")
-    OAI_EXCLUDED_SETS = OAI_CONFIG.get("excluded_sets", [])
-    OAI_ALL_SETS = OAI_CONFIG.get("excluded_sets", "False")
-    OAI_SCHEMATRON_FILTER = OAI_CONFIG.get("schematron_filter", "validations/qdcingest_reqd_fields.sch")
-    OAI_SCHEMATRON_REPORT = OAI_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
+    config_name = name(dag_id) + "_HARVEST_CONFIG"
+    config = Variable.get(config_name, deserialize_json=True)
 
-    XSL_CONFIG = Variable.get(xsl_config_name, default_var={}, deserialize_json=True)
-    XSL_SCHEMATRON_FILTER = XSL_CONFIG.get("schematron_filter", "validations/padigital_reqd_fields.sch")
-    XSL_SCHEMATRON_REPORT = XSL_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
-    XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
-    XSL_BRANCH = XSL_CONFIG.get("xsl_branch", "master")
-    XSL_FILENAME = XSL_CONFIG.get("xsl_filename", "transforms/KLNqdcCDMingest_test.xsl")
+    SCHEMATRON_FILTER = config.get("schematron_filter", "validations/qdcingest_reqd_fields.sch")
+
+    SCHEMATRON_REPORT = config.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
+
+    XSL_REPO = config.get("xsl_repo", "tulibraries/aggregator_mdx")
+
+    XSL_BRANCH = config.get("xsl_branch", "master")
+
+    XSL_FILENAME = config.get("xsl_filename", "transforms/KLNqdcCDMingest_test.xsl")
+
+    target_alias_env_name = name(dag_id) + "_TARGET_ALIAS_ENV"
     TARGET_ALIAS_ENV = Variable.get(target_alias_env_name, default_var="dev")
 
     """
@@ -69,23 +125,7 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
             op_args=["%Y-%m-%d_%H-%M-%S"],
             dag=dag)
 
-        OAI_TO_S3 = PythonOperator(
-            task_id="harvest_oai",
-            provide_context=True,
-            python_callable=harvest.oai_to_s3,
-            op_kwargs={
-                "access_id": AIRFLOW_S3.login,
-                "access_secret": AIRFLOW_S3.password,
-                "all_sets": OAI_ALL_SETS,
-                "bucket_name": AIRFLOW_DATA_BUCKET,
-                "excluded_sets": OAI_EXCLUDED_SETS,
-                "included_sets": OAI_INCLUDED_SETS,
-                "metadata_prefix": OAI_MD_PREFIX,
-                "oai_endpoint": OAI_ENDPOINT,
-                "records_per_file": 10000,
-                "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
-            },
-            dag=dag)
+        HARVEST = get_harvest_task(dag, config)
 
         HARVEST_SCHEMATRON_REPORT = PythonOperator(
             task_id="harvest_schematron_report",
@@ -95,9 +135,9 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
                 "access_id": AIRFLOW_S3.login,
                 "access_secret": AIRFLOW_S3.password,
                 "bucket": AIRFLOW_DATA_BUCKET,
-                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated",
-                "schematron_filename": OAI_SCHEMATRON_REPORT,
-                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/"
+                "destination_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated",
+                "schematron_filename": SCHEMATRON_REPORT,
+                "source_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/"
             },
             dag=dag)
 
@@ -109,10 +149,10 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
                 "access_id": AIRFLOW_S3.login,
                 "access_secret": AIRFLOW_S3.password,
                 "bucket": AIRFLOW_DATA_BUCKET,
-                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated-filtered/",
-                "report_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/harvest_filter",
-                "schematron_filename": OAI_SCHEMATRON_FILTER,
-                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/",
+                "destination_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated-filtered/",
+                "report_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/harvest_filter",
+                "schematron_filename": SCHEMATRON_FILTER,
+                "source_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/",
                 "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
             },
             dag=dag)
@@ -120,11 +160,11 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
         XSL_TRANSFORM = BashOperator(
             task_id="xsl_transform",
             bash_command=SCRIPTS_PATH + "/transform.sh ",
-            env={
+            env={**os.environ, **{
                 "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
                 "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
                 "BUCKET": AIRFLOW_DATA_BUCKET,
-                "DAG_ID": dag.dag_id,
+                "DAG_ID": dag_id,
                 "DAG_TS": "{{ ti.xcom_pull(task_ids='set_collection_name') }}",
                 "DEST": "transformed",
                 "SOURCE": "new-updated-filtered",
@@ -132,7 +172,7 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
                 "XSL_BRANCH": XSL_BRANCH,
                 "XSL_FILENAME": XSL_FILENAME,
                 "XSL_REPO": XSL_REPO,
-            },
+            }},
             dag=dag)
 
         XSL_TRANSFORM_SCHEMATRON_REPORT = PythonOperator(
@@ -143,9 +183,9 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
                 "access_id": AIRFLOW_S3.login,
                 "access_secret": AIRFLOW_S3.password,
                 "bucket": AIRFLOW_DATA_BUCKET,
-                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed",
-                "schematron_filename": XSL_SCHEMATRON_REPORT,
-                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/"
+                "destination_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed",
+                "schematron_filename": SCHEMATRON_REPORT,
+                "source_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/"
             },
             dag=dag)
 
@@ -157,17 +197,17 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
                 "access_id": AIRFLOW_S3.login,
                 "access_secret": AIRFLOW_S3.password,
                 "bucket": AIRFLOW_DATA_BUCKET,
-                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
-                "schematron_filename": XSL_SCHEMATRON_FILTER,
-                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/",
-                "report_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed_filtered",
+                "destination_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
+                "schematron_filename": SCHEMATRON_FILTER,
+                "source_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/",
+                "report_prefix": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed_filtered",
                 "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
             },
             dag=dag)
 
         REFRESH_COLLECTION_FOR_ALIAS = tasks.refresh_sc_collection_for_alias(
             sc_conn=SOLR_CONN,
-            sc_coll_name=f"{SOLR_CONFIGSET}-{dag.dag_id}-{TARGET_ALIAS_ENV}",
+            sc_coll_name=f"{SOLR_CONFIGSET}-{dag_id}-{TARGET_ALIAS_ENV}",
             sc_alias=f"{SOLR_CONFIGSET}-{TARGET_ALIAS_ENV}",
             configset=SOLR_CONFIGSET,
             dag=dag)
@@ -175,17 +215,17 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
         PUBLISH = BashOperator(
             task_id="publish",
             bash_command=SCRIPTS_PATH + "/index.sh ",
-            env={
+            env={**os.environ, **{
                 "BUCKET": AIRFLOW_DATA_BUCKET,
-                "FOLDER": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
+                "FOLDER": dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
                 "INDEXER": "oai_index",
-                "FUNCAKE_OAI_SOLR_URL": tasks.get_solr_url(SOLR_CONN, SOLR_CONFIGSET + "-" + dag.dag_id + "-" + TARGET_ALIAS_ENV),
+                "FUNCAKE_OAI_SOLR_URL": tasks.get_solr_url(SOLR_CONN, SOLR_CONFIGSET + "-" + dag_id + "-" + TARGET_ALIAS_ENV),
                 "SOLR_AUTH_USER": SOLR_CONN.login or "",
                 "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
                 "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
                 "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
                 "AIRFLOW_USER_HOME": AIRFLOW_USER_HOME
-            },
+            }},
             dag=dag)
 
         NOTIFY_SLACK = PythonOperator(
@@ -196,15 +236,25 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
 
 
         # SET UP TASK DEPENDENCIES
-        OAI_TO_S3.set_upstream(SET_COLLECTION_NAME)
-        HARVEST_SCHEMATRON_REPORT.set_upstream(OAI_TO_S3)
-        HARVEST_FILTER.set_upstream(OAI_TO_S3)
+        HARVEST.set_upstream(SET_COLLECTION_NAME)
+
+        HARVEST_SCHEMATRON_REPORT.set_upstream(HARVEST)
+
+        HARVEST_FILTER.set_upstream(HARVEST)
+
         XSL_TRANSFORM.set_upstream(HARVEST_SCHEMATRON_REPORT)
+
         XSL_TRANSFORM.set_upstream(HARVEST_FILTER)
+
         XSL_TRANSFORM_SCHEMATRON_REPORT.set_upstream(XSL_TRANSFORM)
+
         XSL_TRANSFORM_FILTER.set_upstream(XSL_TRANSFORM)
+
         REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_SCHEMATRON_REPORT)
+
         REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_FILTER)
+
         PUBLISH.set_upstream(REFRESH_COLLECTION_FOR_ALIAS)
+
         NOTIFY_SLACK.set_upstream(PUBLISH)
     return dag

--- a/funcake_dags/template.py
+++ b/funcake_dags/template.py
@@ -55,6 +55,7 @@ def get_harvest_task(dag, config):
         return BashOperator(
                 task_id="harvest_csv",
                 bash_command="csv_transform_to_s3.sh ",
+                xcom_push=True,
                 env={**os.environ, **{
                     "PATH": os.environ.get("PATH", "") + ":" + SCRIPTS_PATH,
                     "DAGID": dag.dag_id,

--- a/funcake_dags/template.py
+++ b/funcake_dags/template.py
@@ -1,0 +1,210 @@
+"""DAG Template for DPLA OAI & Index ("Publish") to SolrCloud."""
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.hooks.base_hook import BaseHook
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime, timedelta
+from funcake_dags.task_slack_posts import slackpostonfail, slackpostonsuccess
+from tulflow import harvest, tasks, transform, validate
+
+# Define the DAG
+DEFAULT_ARGS = {
+    "owner": "dpla",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 8, 27),
+    "on_failure_callback": slackpostonfail,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=10),
+}
+
+AIRFLOW_S3 = BaseHook.get_connection("AIRFLOW_S3")
+
+AIRFLOW_DATA_BUCKET = Variable.get("AIRFLOW_DATA_BUCKET")
+
+AIRFLOW_APP_HOME = Variable.get("AIRFLOW_HOME")
+
+AIRFLOW_USER_HOME = Variable.get("AIRFLOW_USER_HOME")
+
+SCRIPTS_PATH = AIRFLOW_APP_HOME + "/dags/funcake_dags/scripts"
+
+SOLR_CONN = BaseHook.get_connection("SOLRCLOUD")
+
+SOLR_CONFIGSET = Variable.get("FUNCAKE_OAI_SOLR_CONFIGSET", default_var="funcake-oai-0")
+
+def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
+    dag = DAG(
+            dag_id=dag_id,
+            default_args=DEFAULT_ARGS,
+            catchup=False,
+            max_active_runs=1,
+            schedule_interval=None)
+
+    OAI_CONFIG = Variable.get(oai_config_name, deserialize_json=True)
+    OAI_MD_PREFIX = OAI_CONFIG.get("md_prefix")
+    OAI_INCLUDED_SETS = OAI_CONFIG.get("included_sets")
+    OAI_ENDPOINT = OAI_CONFIG.get("endpoint")
+    OAI_EXCLUDED_SETS = OAI_CONFIG.get("excluded_sets", [])
+    OAI_ALL_SETS = OAI_CONFIG.get("excluded_sets", "False")
+    OAI_SCHEMATRON_FILTER = OAI_CONFIG.get("schematron_filter", "validations/qdcingest_reqd_fields.sch")
+    OAI_SCHEMATRON_REPORT = OAI_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
+
+    XSL_CONFIG = Variable.get(xsl_config_name, default_var={}, deserialize_json=True)
+    XSL_SCHEMATRON_FILTER = XSL_CONFIG.get("schematron_filter", "validations/padigital_reqd_fields.sch")
+    XSL_SCHEMATRON_REPORT = XSL_CONFIG.get("schematron_report", "validations/padigital_missing_thumbnailURL.sch")
+    XSL_REPO = XSL_CONFIG.get("xsl_repo", "tulibraries/aggregator_mdx")
+    XSL_BRANCH = XSL_CONFIG.get("xsl_branch", "master")
+    XSL_FILENAME = XSL_CONFIG.get("xsl_filename", "transforms/KLNqdcCDMingest_test.xsl")
+    TARGET_ALIAS_ENV = Variable.get(target_alias_env_name, default_var="dev")
+
+    """
+    CREATE TASKS
+    Tasks with all logic contained in a single operator can be declared here.
+    Tasks with custom logic are relegated to individual Python files.
+    """
+    with dag:
+        SET_COLLECTION_NAME = PythonOperator(
+            task_id="set_collection_name",
+            python_callable=datetime.now().strftime,
+            op_args=["%Y-%m-%d_%H-%M-%S"],
+            dag=dag)
+
+        OAI_TO_S3 = PythonOperator(
+            task_id="harvest_oai",
+            provide_context=True,
+            python_callable=harvest.oai_to_s3,
+            op_kwargs={
+                "access_id": AIRFLOW_S3.login,
+                "access_secret": AIRFLOW_S3.password,
+                "all_sets": OAI_ALL_SETS,
+                "bucket_name": AIRFLOW_DATA_BUCKET,
+                "excluded_sets": OAI_EXCLUDED_SETS,
+                "included_sets": OAI_INCLUDED_SETS,
+                "metadata_prefix": OAI_MD_PREFIX,
+                "oai_endpoint": OAI_ENDPOINT,
+                "records_per_file": 10000,
+                "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+            },
+            dag=dag)
+
+        HARVEST_SCHEMATRON_REPORT = PythonOperator(
+            task_id="harvest_schematron_report",
+            provide_context=True,
+            python_callable=validate.report_s3_schematron,
+            op_kwargs={
+                "access_id": AIRFLOW_S3.login,
+                "access_secret": AIRFLOW_S3.password,
+                "bucket": AIRFLOW_DATA_BUCKET,
+                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated",
+                "schematron_filename": OAI_SCHEMATRON_REPORT,
+                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/"
+            },
+            dag=dag)
+
+        HARVEST_FILTER = PythonOperator(
+            task_id="harvest_filter",
+            provide_context=True,
+            python_callable=validate.filter_s3_schematron,
+            op_kwargs={
+                "access_id": AIRFLOW_S3.login,
+                "access_secret": AIRFLOW_S3.password,
+                "bucket": AIRFLOW_DATA_BUCKET,
+                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated-filtered/",
+                "report_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/harvest_filter",
+                "schematron_filename": OAI_SCHEMATRON_FILTER,
+                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/",
+                "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+            },
+            dag=dag)
+
+        XSL_TRANSFORM = BashOperator(
+            task_id="xsl_transform",
+            bash_command=SCRIPTS_PATH + "/transform.sh ",
+            env={
+                "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
+                "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
+                "BUCKET": AIRFLOW_DATA_BUCKET,
+                "DAG_ID": dag.dag_id,
+                "DAG_TS": "{{ ti.xcom_pull(task_ids='set_collection_name') }}",
+                "DEST": "transformed",
+                "SOURCE": "new-updated-filtered",
+                "SCRIPTS_PATH": SCRIPTS_PATH,
+                "XSL_BRANCH": XSL_BRANCH,
+                "XSL_FILENAME": XSL_FILENAME,
+                "XSL_REPO": XSL_REPO,
+            },
+            dag=dag)
+
+        XSL_TRANSFORM_SCHEMATRON_REPORT = PythonOperator(
+            task_id="xsl_transform_schematron_report",
+            provide_context=True,
+            python_callable=validate.report_s3_schematron,
+            op_kwargs={
+                "access_id": AIRFLOW_S3.login,
+                "access_secret": AIRFLOW_S3.password,
+                "bucket": AIRFLOW_DATA_BUCKET,
+                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed",
+                "schematron_filename": XSL_SCHEMATRON_REPORT,
+                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/"
+            },
+            dag=dag)
+
+        XSL_TRANSFORM_FILTER = PythonOperator(
+            task_id="xsl_transform_filter",
+            provide_context=True,
+            python_callable=validate.filter_s3_schematron,
+            op_kwargs={
+                "access_id": AIRFLOW_S3.login,
+                "access_secret": AIRFLOW_S3.password,
+                "bucket": AIRFLOW_DATA_BUCKET,
+                "destination_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
+                "schematron_filename": XSL_SCHEMATRON_FILTER,
+                "source_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/",
+                "report_prefix": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed_filtered",
+                "timestamp": "{{ ti.xcom_pull(task_ids='set_collection_name') }}"
+            },
+            dag=dag)
+
+        REFRESH_COLLECTION_FOR_ALIAS = tasks.refresh_sc_collection_for_alias(
+            sc_conn=SOLR_CONN,
+            sc_coll_name=f"{SOLR_CONFIGSET}-{dag.dag_id}-{TARGET_ALIAS_ENV}",
+            sc_alias=f"{SOLR_CONFIGSET}-{TARGET_ALIAS_ENV}",
+            configset=SOLR_CONFIGSET,
+            dag=dag)
+
+        PUBLISH = BashOperator(
+            task_id="publish",
+            bash_command=SCRIPTS_PATH + "/index.sh ",
+            env={
+                "BUCKET": AIRFLOW_DATA_BUCKET,
+                "FOLDER": dag.dag_id + "/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/",
+                "INDEXER": "oai_index",
+                "FUNCAKE_OAI_SOLR_URL": tasks.get_solr_url(SOLR_CONN, SOLR_CONFIGSET + "-" + dag.dag_id + "-" + TARGET_ALIAS_ENV),
+                "SOLR_AUTH_USER": SOLR_CONN.login or "",
+                "SOLR_AUTH_PASSWORD": SOLR_CONN.password or "",
+                "AWS_ACCESS_KEY_ID": AIRFLOW_S3.login,
+                "AWS_SECRET_ACCESS_KEY": AIRFLOW_S3.password,
+                "AIRFLOW_USER_HOME": AIRFLOW_USER_HOME
+            },
+            dag=dag)
+
+        NOTIFY_SLACK = PythonOperator(
+            task_id="success_slack_trigger",
+            provide_context=True,
+            python_callable=slackpostonsuccess,
+            dag=dag)
+
+
+        # SET UP TASK DEPENDENCIES
+        OAI_TO_S3.set_upstream(SET_COLLECTION_NAME)
+        HARVEST_SCHEMATRON_REPORT.set_upstream(OAI_TO_S3)
+        HARVEST_FILTER.set_upstream(OAI_TO_S3)
+        XSL_TRANSFORM.set_upstream(HARVEST_SCHEMATRON_REPORT)
+        XSL_TRANSFORM.set_upstream(HARVEST_FILTER)
+        XSL_TRANSFORM_SCHEMATRON_REPORT.set_upstream(XSL_TRANSFORM)
+        XSL_TRANSFORM_FILTER.set_upstream(XSL_TRANSFORM)
+        REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_SCHEMATRON_REPORT)
+        REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_FILTER)
+        PUBLISH.set_upstream(REFRESH_COLLECTION_FOR_ALIAS)
+        NOTIFY_SLACK.set_upstream(PUBLISH)
+    return dag

--- a/funcake_dags/template.py
+++ b/funcake_dags/template.py
@@ -207,4 +207,6 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
         REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_FILTER)
         PUBLISH.set_upstream(REFRESH_COLLECTION_FOR_ALIAS)
         NOTIFY_SLACK.set_upstream(PUBLISH)
+
+    globals()[dag_id] = dag
     return dag

--- a/funcake_dags/template.py
+++ b/funcake_dags/template.py
@@ -207,6 +207,4 @@ def create_dag(dag_id, oai_config_name, xsl_config_name, target_alias_env_name):
         REFRESH_COLLECTION_FOR_ALIAS.set_upstream(XSL_TRANSFORM_FILTER)
         PUBLISH.set_upstream(REFRESH_COLLECTION_FOR_ALIAS)
         NOTIFY_SLACK.set_upstream(PUBLISH)
-
-    globals()[dag_id] = dag
     return dag

--- a/funcake_dags/template_dag.py
+++ b/funcake_dags/template_dag.py
@@ -1,0 +1,30 @@
+from funcake_dags.template import create_dag
+
+"""
+This file will automatically create a dag for every dag_id added to the dag_ids array below.
+
+It will also assume the associated airflow variables are present in airflow. For example for the id 'westchester' the following associated airflow variables will be assumed to exist:
+
+WESTCHESTER_HARVEST_CONFIG
+WESTCHESTER_TARGET_ALIAS_ENV (can be prod, dev .. it's dev by default)
+
+Example of Harvest Config value
+{
+    "endpoint": "http://digital.klnpa.org/oai/oai.php",
+    "md_prefix": "oai_qdc",
+    "all_sets": "False", <--- OPTIONAL
+    "excluded_sets": [], <--- OPTIONAL
+    "included_sets": ["aebye","ajt","amc", ...], <--- OPTIONAL
+    "schematron_filter": "validations/dcingest_reqd_fields.sch",
+    "schematron_report": "validations/padigital_missing_thumbnailURL.sch"
+}
+"""
+
+# Note that ids will automatically be prefixed with 'funcake_' as a namespace.
+# The dag_id for "westchester" will automatically be "funcake_westchester".
+
+dag_ids = []
+
+for dag_id in dag_ids:
+    dag = create_dag(dag_id)
+    globals()[dag.dag_id] = dag

--- a/tests/template_test.py
+++ b/tests/template_test.py
@@ -1,0 +1,95 @@
+import airflow
+from funcake_dags.template import create_dag
+import unittest
+from datetime import datetime, timedelta
+
+AIRFLOW_APP_HOME = airflow.models.Variable.get("AIRFLOW_HOME")
+
+SCRIPTS_PATH = AIRFLOW_APP_HOME + "/dags/funcake_dags/scripts"
+
+class TestTemplate(unittest.TestCase):
+    def setUp(self):
+        airflow.models.Variable.set("TEST_OAI_CONFIG", {
+            "xsl_branch": "master",
+            "xsl_filename": "transforms/dplah.xsl",
+            "xsl_repo": "tulibraries/aggregator_mdx",
+            "schematron_filter": "validations/padigital_reqd_fields.sch",
+            "schematron_report": "validations/padigital_missing_thumbnailURL.sch",
+            "endpoint": "foobar",
+            }, serialize_json=True)
+
+        airflow.models.Variable.set("TEST_XSL_CONFIG", {
+            "schematron_filter": "validations/funcake_reqd_fields.sch",
+            "schematron_report": "validations/padigital_missing_thumbnailURL.sch",
+            "xsl_branch": "master",
+            "xsl_filename": "transforms/dplah.xsl",
+            "xsl_repository": "tulibraries/aggregator_mdx",
+            }, serialize_json=True)
+
+        self.dag = create_dag(
+                dag_id="foo",
+                oai_config_name="TEST_OAI_CONFIG",
+                xsl_config_name="TEST_XSL_CONFIG",
+                target_alias_env_name="TEST_ALIAS_ENV")
+
+    def test_create_dag(self):
+        """Assert expected DAG exists."""
+        self.assertEqual(self.dag.dag_id, "foo")
+
+    def test_set_collection_name_task(self):
+        task = self.dag.get_task("set_collection_name")
+        self.assertIn(task.python_callable.__qualname__, "datetime.strftime")
+
+    def test_harvest_oai_task(self):
+        task = self.dag.get_task("harvest_oai")
+        self.assertEqual(task.op_kwargs["bucket_name"], "test-s3-bucket")
+        self.assertEqual(task.op_kwargs["oai_endpoint"], "foobar")
+
+    def test_harvest_schematron_report_task(self):
+        task = self.dag.get_task("harvest_schematron_report")
+        self.assertEqual(task.op_kwargs["bucket"], "test-s3-bucket")
+        self.assertEqual(task.op_kwargs["destination_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated")
+        self.assertEqual(task.op_kwargs["source_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/")
+
+    def test_harves_filter_task(self):
+        task = self.dag.get_task("harvest_filter")
+        self.assertEqual(task.op_kwargs["bucket"], "test-s3-bucket")
+        self.assertEqual(task.op_kwargs["schematron_filename"], "validations/padigital_reqd_fields.sch")
+        self.assertEqual(task.op_kwargs["destination_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated-filtered/")
+        self.assertEqual(task.op_kwargs["report_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/harvest_filter")
+        self.assertEqual(task.op_kwargs["source_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated/")
+
+    def test_xsl_transform_task(self):
+        task = self.dag.get_task("xsl_transform")
+        self.assertEqual(task.bash_command, SCRIPTS_PATH + "/transform.sh " )
+        self.assertEqual(task.env["XSL_BRANCH"], "master" )
+
+    def test_xsl_transform_schematron_report_task(self):
+        task = self.dag.get_task("xsl_transform_schematron_report")
+        self.assertEqual(task.op_kwargs["schematron_filename"], "validations/padigital_missing_thumbnailURL.sch")
+        self.assertEqual(task.op_kwargs["destination_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed")
+        self.assertEqual(task.op_kwargs["source_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/")
+
+    def test_xsl_transform_filter_task(self):
+        task = self.dag.get_task("xsl_transform_filter")
+        self.assertEqual(task.op_kwargs["schematron_filename"], "validations/funcake_reqd_fields.sch")
+        self.assertEqual(task.op_kwargs["destination_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed-filtered/")
+        self.assertEqual(task.op_kwargs["source_prefix"], "foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/transformed/")
+
+    def test_refresh_alias_task(self):
+        task = self.dag.get_task("refresh_sc_collection_for_alias")
+        self.assertEqual(task.op_kwargs["alias"], "funcake-oai-0-dev")
+        self.assertEqual(task.op_kwargs["collection"], "funcake-oai-0-foo-dev")
+
+    def test_pulish_stask(self):
+        task = self.dag.get_task("publish")
+        self.assertEqual(task.bash_command, SCRIPTS_PATH + "/index.sh " )
+        self.assertEqual(task.env["FUNCAKE_OAI_SOLR_URL"], "http://127.0.0.1:8983/solr/funcake-oai-0-foo-dev" )
+
+    def test_success_slack_trigger__task(self):
+        task = self.dag.get_task("success_slack_trigger")
+        self.assertIn(task.python_callable.__qualname__, "slackpostonsuccess")
+
+    def test_all_task_are_linked_to_something(self):
+        for task in self.dag.tasks:
+            self.assertTrue(task.upstream_list != [] or task.downstream_list != [], "Expect all tasks to be linked to eachother.")

--- a/tests/template_test.py
+++ b/tests/template_test.py
@@ -94,3 +94,4 @@ class TestTemplate(unittest.TestCase):
         dag = create_dag("foo")
         task = dag.get_task("harvest_csv")
         self.assertEqual(task.env["FOLDER"], "funcake_foo/{{ ti.xcom_pull(task_ids='set_collection_name') }}/new-updated")
+        self.assertEqual(task.xcom_push_flag, True, "Enable xcom_push for reporting.")


### PR DESCRIPTION
Adds a new `funcake_dags/template_dag.py` that can generate funcake dags
dynamically from supplied dag_ids array.

### Features:
* Generates funcake dags from supplied `dag_ids` array.
* Chooses the correct harvesting task between oai endpoints or csv
* Namespaces the dag_id with "funcake_"