### PR TITLE
Fix template dag not parsed.

### DIFF
--- a/funcake_dags/template_dag.py
+++ b/funcake_dags/template_dag.py
@@ -1,4 +1,5 @@
 from funcake_dags.template import create_dag
+from airflow import DAG # Required or airflow-webserver skips file.
 
 """
 This file will automatically create a dag for every dag_id added to the dag_ids array below.


### PR DESCRIPTION
The airflow webserver only parses files that it determines have dags defined by looking for the airflow.DAG method.  If a file does not import this method, it does not get parsed in the initial airflow-webserver setup, and even if dags are being defined behind a layer of abstraction, they will not show up on the airflow dashboard.