### PR TITLE
FLYPIE-201 Redirect all output to file.

### DIFF
--- a/funcake_dags/scripts/index.sh
+++ b/funcake_dags/scripts/index.sh
@@ -26,7 +26,7 @@ trap 'rm -f $TEMPFILE' EXIT
 
 for record_set in `echo $RESP`
 do
-  bundle exec $INDEXER ingest $(aws s3 presign s3://$BUCKET/$FOLDER$record_set) | tee -a $TEMPFILE
+  bundle exec $INDEXER ingest $(aws s3 presign s3://$BUCKET/$FOLDER$record_set) 2>&1 | tee -a $TEMPFILE
 done
 
 PUBLISH_TASK_REPORT=$AIRFLOW_HOME/dags/funcake_dags/scripts/publish_task_report.rb


### PR DESCRIPTION
Redirect all output not just standard output for cob_index/traject.
The output that we want to parse is not in the standard output so we
need to redirect all of it in order to parse it correctly.