### PR TITLE
FLYPIE-174: Do not add empty fields to xml from csv.

### DIFF
--- a/funcake_dags/scripts/csv_to_xml.py
+++ b/funcake_dags/scripts/csv_to_xml.py
@@ -10,20 +10,31 @@ DAGID = os.environ.get("DAGID")
 TIMESTAMP = os.environ.get("TIMESTAMP")
 
 CSV_FILES = [f for f in os.listdir(".") if f.endswith(".csv") or f.endswith(".CSV")]
-for file in CSV_FILES:
-    with open(file, encoding="ISO-8859-1") as ifile:
-        XML_FILE = file[:-4] + ".xml"
-        DATA = csv.reader(ifile)
-        XML_DATA = etree.Element("collection")
-        XML_DATA.attrib["dag-id"] = DAGID
-        XML_DATA.attrib["dag-timestamp"] = TIMESTAMP
-        HEADERS = next(DATA, None) # skip the HEADERS
-        for count, record in enumerate(DATA):
-            record_xml = etree.SubElement(XML_DATA, "record")
-            record_xml.attrib["airflow-record-id"] = str(count + 1)
-            for i, field in enumerate(record):
-                header = HEADERS[i].strip(" ").replace(" ", "_")
+
+def csv_reader_to_xml_string(csv_reader, dag_id, timestamp):
+    root = etree.Element("collection")
+    root.attrib["dag-id"] = dag_id
+    root.attrib["dag-timestamp"] = timestamp
+
+    headers = next(csv_reader, None) # skip the HEADERS
+    for count, record in enumerate(csv_reader):
+        record_xml = etree.SubElement(root, "record")
+        record_xml.attrib["airflow-record-id"] = str(count + 1)
+        for i, field in enumerate(record):
+            if field:
+                header = headers[i].strip(" ").replace(" ", "_")
                 field_xml = etree.SubElement(record_xml, header)
                 field_xml.text = field
-    with open(XML_FILE, "wb") as ofile:
-        ofile.write(etree.tostring(XML_DATA, pretty_print=True))
+    return etree.tostring(root, pretty_print=True)
+
+def main():
+    for file in CSV_FILES:
+        with open(file, encoding="ISO-8859-1") as ifile:
+            XML_FILE = file[:-4] + ".xml"
+            csv_reader = csv.reader(ifile)
+            xml_string = csv_reader_to_xml_string(csv_reader, DAGID, TIMESTAMP)
+        with open(XML_FILE, "wb") as ofile:
+            ofile.write(xml_string)
+
+if __name__ == "__main__":
+    main()

--- a/tests/csv_to_xml_test.py
+++ b/tests/csv_to_xml_test.py
@@ -1,0 +1,14 @@
+import unittest
+from funcake_dags.scripts.csv_to_xml import csv_reader_to_xml_string
+import csv
+
+class TestCsvToXml(unittest.TestCase):
+
+    def test_csv_reader_to_xml_string(self):
+        csv_string = "foo, bar, buzz\n1,,2"
+        csv_reader = csv.reader(csv_string.splitlines(), delimiter=',')
+
+        expected = b'<collection dag-id="foo" dag-timestamp="bar">\n  <record airflow-record-id="1">\n    <foo>1</foo>\n    <buzz>2</buzz>\n  </record>\n</collection>\n'
+
+        actual = csv_reader_to_xml_string(csv_reader, "foo", "bar")
+        self.assertEqual(actual, expected, "Assert that empty fields are not added.")


### PR DESCRIPTION
When we transform csv to xml, if the field is empty in the xml it is
still counted in the field count report.

This commit updates the csv to xml script to skip adding fields that are
empty to the xml.