### PR TITLE
Added dag id for La Salle BePress repository

### DIFF
--- a/funcake_dags/template_dag.py
+++ b/funcake_dags/template_dag.py
@@ -31,7 +31,7 @@ Example of Harvest Config value
 
 dag_ids = [
     "lasalle_cdm",
-    "lasalle_bepress"
+    "lasalle_bepress",
     "lehigh_csv",
     "penn_walters_csv",
     "shi",

--- a/funcake_dags/template_dag.py
+++ b/funcake_dags/template_dag.py
@@ -31,6 +31,7 @@ Example of Harvest Config value
 
 dag_ids = [
     "lasalle_cdm",
+    "lasalle_bepress"
     "lehigh_csv",
     "penn_walters_csv",
     "shi",


### PR DESCRIPTION
There already seems to be a dag id for lasalle_cdm. I will label the new bepress dag id lasalle_bepress. 