### PR TITLE
add new dag to test static xml ingest

### DIFF
--- a/funcake_dags/template_dag.py
+++ b/funcake_dags/template_dag.py
@@ -61,6 +61,7 @@ dag_ids = [
     "statelibrary_csv",
     "catholicresearchctr",
     "aps",
+    "aps_static",
     "curtis",
     "tju",
     "ursinus",

--- a/variables.json
+++ b/variables.json
@@ -300,6 +300,16 @@
     "xsl_repository": "tulibraries/aggregator_mdx"
   },
   "APS_TARGET_ALIAS_ENV": "dev",
+  "APS_STATIC_HARVEST_CONFIG": {
+    "schematron_filter": "validations/dcingest_reqd_fields.sch",
+    "schematron_report": "validations/padigital_missing_thumbnailURL.sch",
+    "schematron_xsl_filter": "validations/padigital_reqd_fields.sch",
+    "schematron_xsl_report": "validations/padigital_missing_thumbnailURL.sch",
+    "xsl_branch": "main",
+    "xsl_filename": "transforms/historicpitt.xsl",
+    "xsl_repository": "tulibraries/aggregator_mdx"
+  },
+  "APS_STATIC_TARGET_ALIAS_ENV": "dev",
     "SHI_HARVEST_CONFIG": {
     "endpoint": "https://digital.sciencehistory.org/oai",
     "md_prefix": "oai_dc",


### PR DESCRIPTION
What this PR does:
- Add new dag to test static xml ingest: aps_static
- Update variables.json for the new dag