### PR TITLE
Update variables to test aps_static

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -306,7 +306,7 @@
     "schematron_xsl_filter": "validations/padigital_reqd_fields.sch",
     "schematron_xsl_report": "validations/padigital_missing_thumbnailURL.sch",
     "xsl_branch": "main",
-    "xsl_filename": "transforms/historicpitt.xsl",
+    "xsl_filename": "transforms/historicpitt_static.xsl",
     "xsl_repository": "tulibraries/aggregator_mdx"
   },
   "APS_STATIC_TARGET_ALIAS_ENV": "dev",


### PR DESCRIPTION
What this PR does:

- Update variables.json to use historicpitt_static.xsl for aps_static dag

(Note: already tested this by changing variable manually in the Airflow UI and confirmed it works)