### PR TITLE
Skip processing empty files.

### DIFF
--- a/funcake_dags/scripts/transform.sh
+++ b/funcake_dags/scripts/transform.sh
@@ -49,6 +49,12 @@ do
 	java -jar $SAXON_CP -xsl:$SCRIPTS_PATH/batch-transform.xsl -s:$SOURCE_XML-2.xml -o:$SOURCE_XML-transformed.xml -t
 	COUNT=$(cat $SOURCE_XML-transformed.xml | grep -o "<oai_dc:dc" | wc -l)
 	TOTAL_TRANSFORMED=$(expr $TOTAL_TRANSFORMED + $COUNT)
+
+  if [ $COUNT == 0]; then
+    # Skip further processing empty files.
+    continue
+  fi
+
 	aws s3 cp $SOURCE_XML-transformed.xml s3://$BUCKET/$TRANSFORM_XML
 
 	TEMPFILE=$(mktemp /tmp/identifier-output.XXXXXX)


### PR DESCRIPTION
This may fix issue of failure when we process the empty file. Looks like
the actual failure happens when we try to push the "processed" file up
to s3. So, skipping that should fix issue.