### PR TITLE
Revert "Skip processing empty files."

### DIFF
--- a/funcake_dags/scripts/transform.sh
+++ b/funcake_dags/scripts/transform.sh
@@ -49,12 +49,6 @@ do
 	java -jar $SAXON_CP -xsl:$SCRIPTS_PATH/batch-transform.xsl -s:$SOURCE_XML-2.xml -o:$SOURCE_XML-transformed.xml -t
 	COUNT=$(cat $SOURCE_XML-transformed.xml | grep -o "<oai_dc:dc" | wc -l)
 	TOTAL_TRANSFORMED=$(expr $TOTAL_TRANSFORMED + $COUNT)
-
-  if [ $COUNT == 0]; then
-    # Skip further processing empty files.
-    continue
-  fi
-
 	aws s3 cp $SOURCE_XML-transformed.xml s3://$BUCKET/$TRANSFORM_XML
 
 	TEMPFILE=$(mktemp /tmp/identifier-output.XXXXXX)


### PR DESCRIPTION
Reverts tulibraries/funcake_dags#330

Reverting because it doesn't look like this fixes issue. Even though from log it looks like script gets upto the count step without error, it still fails. It would probably require downloading the xml file locally and processing it locally instead of via URL.