### PR TITLE
Remove papd_shswp-bfp from setSpec list

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -497,7 +497,6 @@
       "papd_kfces-photo",
       "papd_agene-pcard",
       "papd_sgsop-wagsp",
-      "papd_shswp-bfp",
       "papd_pjvbl-archi",
       "papd_akeyscmath",
       "papd_kthks-tksc",


### PR DESCRIPTION
This collection is being withdrawn from papd repository. 