### PR TITLE
Remove duplicate setspec from Historic Pittsburgh variables

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -64,6 +64,7 @@
       "blmmap",
       "blmphoto",
       "blmpost",
+      "blmwwi",
       "CHSminutes"
     ],
     "schematron_filter": "validations/ingest_oai_validation.sch",

--- a/variables.json
+++ b/variables.json
@@ -377,7 +377,6 @@
       "pitt_collection.151",
       "pitt_collection.152",
       "pitt_collection.154",
-      "pitt_collection.154",
       "pitt_collection.155",
       "pitt_collection.156",
       "pitt_collection.157",


### PR DESCRIPTION
- Remove duplicate of pitt_collection.154, which was being harvested twice