### PR TITLE
Force ruby platform for bundle install.

### DIFF
--- a/funcake_dags/scripts/index.sh
+++ b/funcake_dags/scripts/index.sh
@@ -16,6 +16,7 @@ set -aux
 git clone https://github.com/tulibraries/$INDEXER.git tmp/$INDEXER
 cd tmp/$INDEXER
 gem install bundler
+bundle config set force_ruby_platform true
 bundle install
 
 # grab list of items from designated aws bucket (creds are envvars), then index each item


### PR DESCRIPTION
Nokogiri is failing to run due to missing library.

This change forces it to use ruby instead of native library.
