### PR TITLE
Combine_Index timeout

### DIFF
--- a/funcake_dags/funcake_prod_index_dag.py
+++ b/funcake_dags/funcake_prod_index_dag.py
@@ -111,6 +111,7 @@ COMBINE_INDEX = BashOperator(
         "AIRFLOW_USER_HOME": AIRFLOW_USER_HOME,
         "AIRFLOW_APP_HOME": AIRFLOW_APP_HOME
     },
+        execution_timeout=timedelta(hours=6),
     dag=DAG
 )
 


### PR DESCRIPTION
The task exceeded its allowed runtime, or hit resource limits. This tries to increase the timeout before changing resource limits.